### PR TITLE
[bug] change relation datatable. Global filtering option available.

### DIFF
--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -147,7 +147,7 @@
       <path value="$PROJECT_DIR$/src/vendor/nunomaduro/termwind" />
     </include_path>
   </component>
-  <component name="PhpProjectSharedConfiguration" php_language_level="7.3">
+  <component name="PhpProjectSharedConfiguration" php_language_level="8.1">
     <option name="suggestChangeDefaultLanguageLevel" value="false" />
   </component>
   <component name="PhpUnit">

--- a/src/app/Http/Livewire/LinksDatatables.php
+++ b/src/app/Http/Livewire/LinksDatatables.php
@@ -3,7 +3,6 @@
 namespace App\Http\Livewire;
 
 
-use App\Models\Field;
 use App\Models\Link;
 use App\Models\Relation;
 use Illuminate\Support\Facades\Auth;
@@ -19,8 +18,8 @@ class LinksDatatables extends LivewireDatatable
     {
         /*return Link::query()
             ->whereNull("links.deleted_at")
-            ->leftJoin('refugees as from_refugee', 'from_refugee.id', 'links.from')
-            ->leftJoin('refugees as to_refugee', 'to_refugee.id', 'links.to')
+            ->leftJoin('field_refugees as from_refugee', 'from_refugee.id', 'links.from')
+            ->leftJoin('field_refugees as to_refugee', 'to_refugee.id', 'links.to')
             ->leftJoin('relations', 'relations.id', 'links.relation');
 
         */
@@ -34,6 +33,7 @@ class LinksDatatables extends LivewireDatatable
      */
     public function columns()
     {
+        /*
         $arr = [];
         foreach (Field::all() as $field) {
             array_push($arr,
@@ -42,6 +42,20 @@ class LinksDatatables extends LivewireDatatable
                         ->fields->where("label", $field->label)->first()->pivot->value;
                 })->label($field->title), (string)$field->id);
         }
+    */
+
+
+        return [
+
+            Column::name('refugeeFrom.id')->label('From'),
+            //Column::name('refugeeFrom.bestDescriptiveValue.value'),
+            Column::name('relation.name')
+                ->filterable(Relation::pluck(Relation::getDisplayedValue()))->label('Relation'),
+            Column::name('refugeeTo.id')->label('To'),
+            // Column::name('refugeeTo.bestDescriptiveValue.value'),
+
+        ];
+
 
         return [
             Column::callback('id', function ($id) {
@@ -56,12 +70,14 @@ class LinksDatatables extends LivewireDatatable
                 ->filterable()
                 ->label('From name'),
 
-            Column::callback('id', function ($id) {
-                return Link::find($id)->relation;
-            }, ["2"])
-                ->filterable(Relation::pluck(Relation::getDisplayedValue()))
-                ->label('Relation')
-                ->alignCenter(),
+//            Column::callback('id', function ($id) {
+//                return Link::find($id)->relation;
+//            }, ["2"])
+//                ->filterable(Relation::pluck(Relation::getDisplayedValue()))
+//                ->label('Relation')
+//                ->alignCenter(),
+            Column::name('relation.name')
+                ->filterable(Relation::pluck(Relation::getDisplayedValue())),
 
             Column::callback('id', function ($id) {
                 $ref = Link::find($id)->refugeeTo;

--- a/src/resources/views/links/index.blade.php
+++ b/src/resources/views/links/index.blade.php
@@ -23,11 +23,41 @@
             <div class="flex flex-col">
                 <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
                     <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-                        <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg p-2">
+                        {{--<div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg p-2">
                             <livewire:links-datatables
                                 per-page="25"
                                 exportable
                             />
+                        </div>--}}
+                        <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg p-2">
+                            <table id="person" class="display">
+                                <thead>
+                                <tr>
+                                    <th>From</th>
+                                    <th>Relation</th>
+                                    <th>To</th>
+                                    @can('update', $links->first())
+                                        <th></th>
+                                    @endcan
+                                </tr>
+                                </thead>
+                                <tbody>
+                                @foreach($links as $link)
+                                    <tr>
+                                        <td>
+                                            <a href="{{route('person.show',  $link->refugeeFrom->id)}}"> {{ $link->refugeeFrom->best_descriptive_value }}</a>
+                                        </td>
+                                        <td>{{ $link->relation }}</td>
+                                        <td>
+                                            <a href="{{route('person.show',  $link->refugeeTo->id)}}">{{ $link->refugeeTo->best_descriptive_value }}</a>
+                                        </td>
+                                        @can('update', $link)
+                                            <td><a href="{{route('links.edit',  $link->id)}}">Edit</a></td>
+                                        @endcan
+                                    </tr>
+                                @endforeach
+                                </tbody>
+                            </table>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Signed-off-by: Lduf <lucas.dufour@insa-lyon.fr>

### Description
Change the datatable to allow data search

## Issues fixed
List of related issues that are fixed by this PR :

- Closed #198 


### Checklist
- [ ] Compiling
- [ ] Code factoring (comments, indent...)
- [ ] Documentation (net4p Doc, Readme...)

### Feature Checklist
- [ ] Cytoscape
- [ ] Person/Index
- [ ] Person/Filter
- [ ] Person/Create
- [ ] Person/Edit
- [ ] Person/Delete
- [x] Relation/Index
- [x] Relation/Filter
- [x] Relation/Create
- [x] Relation/Edit
- [x] Relation/Delete
- [ ] Duplicates/Index
- [ ] Duplicates/Filter
- [ ] Duplicates/Create
- [ ] Duplicates/Edit
- [ ] ManageList/Delete
- [ ] ManageList/Create
- [ ] ManageList/Edit
- [ ] ManageField/Index
- [ ] ManageField/Create
- [ ] ManageField/Edit
- [ ] ManageField/Delete
- [ ] ApiList
- [ ] Crews
- [ ] Users
