### PR TITLE
[PR] Feature/issue 329  new feature basic duplicate section

### DIFF
--- a/src/app/Console/Commands/DuplicateCommand.php
+++ b/src/app/Console/Commands/DuplicateCommand.php
@@ -56,6 +56,7 @@ class DuplicateCommand extends Command
                     $duplicate = Duplicate::updateOrCreate([
                         "person1_id" => $person,
                         "person2_id" => $person2,
+                        "crew_id" => $crew->id,
                     ]);
                     $duplicate->similarity = $similarity;
                     $duplicate->command_run_id = $command->id;

--- a/src/app/Console/Commands/DuplicateCommand.php
+++ b/src/app/Console/Commands/DuplicateCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\CommandRun;
+use App\Models\Crew;
+use App\Models\Duplicate;
+use Illuminate\Console\Command;
+
+class DuplicateCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'duplicate:compute';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This command computes the duplicates';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle() {
+        // Step 1 : Add the command to the command_run table
+        $command = CommandRun::start('duplicate:compute');
+
+        // Step 2 : Compute the duplicates
+        // 2.1 : Get all the crew
+
+        $crews = Crew::all();
+
+        // 2.2 : For each crew, get all the refugees
+
+        foreach ($crews as $crew) {
+            //print INFO
+            $this->info("Computing duplicates for crew ".$crew->name);
+
+            // 2.3 : For each refugee, compute similarity with all the other refugees.
+            // Do not compute the similarity with the same refugee,
+            // Do not compute the similarity with a refugee that has already been compared and not edited since.
+            //Do not compute the similarity with refugees that has been marked as resolve.
+            $crewSimilarities = Duplicate::compute($crew);
+            $this->info(count($crewSimilarities)." persons computed for crew ".$crew->name);
+
+            // Step 3 : Add the similarities to the duplicates table
+            foreach ($crewSimilarities as $person => $personSimilarities) {
+                foreach ($personSimilarities as $person2 => $similarity) {
+                    $duplicate = Duplicate::updateOrCreate([
+                        "person1_id" => $person,
+                        "person2_id" => $person2,
+                    ]);
+                    $duplicate->similarity = $similarity;
+                    $duplicate->command_run_id = $command->id;
+                    $duplicate->save();
+                }
+            }
+        }
+
+        // Step 4 : Mark the command as finished
+        $command->end();
+
+        return Command::SUCCESS;
+    }
+
+
+}

--- a/src/app/Console/Kernel.php
+++ b/src/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\DuplicateCommand;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -12,19 +13,18 @@ class Kernel extends ConsoleKernel
      *
      * @var array
      */
-    protected $commands = [
-        //
+    protected $commands = [//
     ];
+
 
     /**
      * Define the application's command schedule.
      *
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @param  Schedule  $schedule
      * @return void
      */
-    protected function schedule(Schedule $schedule)
-    {
-        // $schedule->command('inspire')->hourly();
+    protected function schedule(Schedule $schedule) {
+        $schedule->command(DuplicateCommand::class)->everyFiveMinutes()->withoutOverlapping();
     }
 
     /**
@@ -32,10 +32,11 @@ class Kernel extends ConsoleKernel
      *
      * @return void
      */
-    protected function commands()
-    {
+    protected function commands() {
         $this->load(__DIR__.'/Commands');
 
         require base_path('routes/console.php');
     }
+
+
 }

--- a/src/app/Http/Controllers/DuplicateController.php
+++ b/src/app/Http/Controllers/DuplicateController.php
@@ -14,12 +14,13 @@ class DuplicateController extends Controller
      *
      * @return Response
      */
-    public function index()
-    {
-        $this->authorize("viewAny", Auth::user());
-        //$duplicates = Duplicate::getDuplicates();
-        $duplicates = [];
-        return view("duplicate.index", compact("duplicates"));
+    public function index() {
+        $this->authorize("viewAny",
+            Auth::user());
+        $duplicates = Duplicate::getSimilarRefugees(Auth::user()->crew);
+        dd($duplicates);
+        return view("duplicate.index",
+            compact("duplicates"));
     }
 
     /**
@@ -27,64 +28,59 @@ class DuplicateController extends Controller
      *
      * @return Response
      */
-    public function create()
-    {
+    public function create() {
         //
     }
 
     /**
      * Store a newly created resource in storage.
      *
-     * @param Request $request
+     * @param  Request  $request
      * @return Response
      */
-    public function store(Request $request)
-    {
+    public function store(Request $request) {
         //
     }
 
     /**
      * Display the specified resource.
      *
-     * @param Duplicate $duplicate
+     * @param  Duplicate  $duplicate
      * @return Response
      */
-    public function show(Duplicate $duplicate)
-    {
+    public function show(Duplicate $duplicate) {
         //
     }
 
     /**
      * Show the form for editing the specified resource.
      *
-     * @param Duplicate $duplicate
+     * @param  Duplicate  $duplicate
      * @return Response
      */
-    public function edit(Duplicate $duplicate)
-    {
+    public function edit(Duplicate $duplicate) {
         //
     }
 
     /**
      * Update the specified resource in storage.
      *
-     * @param Request $request
-     * @param Duplicate $duplicate
+     * @param  Request  $request
+     * @param  Duplicate  $duplicate
      * @return Response
      */
-    public function update(Request $request, Duplicate $duplicate)
-    {
+    public function update(Request $request,
+        Duplicate $duplicate) {
         //
     }
 
     /**
      * Remove the specified resource from storage.
      *
-     * @param Duplicate $duplicate
+     * @param  Duplicate  $duplicate
      * @return Response
      */
-    public function destroy(Duplicate $duplicate)
-    {
+    public function destroy(Duplicate $duplicate) {
         //
     }
 }

--- a/src/app/Http/Controllers/ManageUsersController.php
+++ b/src/app/Http/Controllers/ManageUsersController.php
@@ -144,7 +144,7 @@ class ManageUsersController extends Controller
         if ($v->fails()) {
             return redirect()->back()->withErrors(['cantDeleteUser' => $v->errors()]);
         } else {
-            $user->delete();
+            $user->forceDelete();
             return redirect()->route("user.index");
         }
 

--- a/src/app/Http/Controllers/RefugeeController.php
+++ b/src/app/Http/Controllers/RefugeeController.php
@@ -82,6 +82,7 @@ class RefugeeController extends Controller
         $old = array_combine($ids,
             $values);
 
+        
         foreach (array_diff($request->validated(),
             $old) as $key => $value) {
             if (!empty($value)) {
@@ -92,8 +93,12 @@ class RefugeeController extends Controller
                 } else {
                     $person->fields()->attach([$key => ['value' => $value]]);
                 }
+                unset($old[$key]);
+                unset($request->validated()[$key]);
             }
         }
+
+
         //detach fields that are not in the request
         foreach (array_diff($old,
             $request->validated()) as $key => $value) {

--- a/src/app/Models/CommandRun.php
+++ b/src/app/Models/CommandRun.php
@@ -2,10 +2,15 @@
 
 namespace App\Models;
 
+use App\Console\Kernel;
 use App\Traits\Uuids;
+use Carbon\Carbon;
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Str;
 
 
 class CommandRun extends Model
@@ -55,10 +60,37 @@ class CommandRun extends Model
      */
 
     public static function lastEnded(string $command): CommandRun|null {
-        $lastCommandRun = CommandRun::where("command",
-            $command)->orderBy("ended_at",
-            "desc")->first();
-        return $lastCommandRun;
+        return CommandRun::whereCommand($command)->orderByDesc("ended_at")->first();
+    }
+
+    /**
+     * Get the next due date for the command
+     *
+     * @param  string  $command
+     * @return Carbon
+     */
+
+    public static function nextDue(string $command): Carbon|null {
+        // Execute php artisan schedule:list to see the schedule
+
+        new Kernel(app(),
+            new Dispatcher());
+        $schedule = app(Schedule::class);
+        $tasks = collect($schedule->events());
+        $matches = $tasks->filter(function ($item) use
+        (
+            $command
+        ) {
+            return Str::contains($item->command,
+                $command);
+        });
+
+// assuming you get something back in that collection
+        if ($matches->count() > 0) {
+            return $matches->first()->nextRunDate();
+        }
+        return null;
+
     }
 
     /**
@@ -71,4 +103,5 @@ class CommandRun extends Model
         $this->save();
         return $this;
     }
+
 }

--- a/src/app/Models/CommandRun.php
+++ b/src/app/Models/CommandRun.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\Uuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+
+class CommandRun extends Model
+{
+    use HasFactory, Uuids, SoftDeletes;
+
+    /**
+     * Indicates if the model's ID is auto-incrementing.
+     *
+     * @var bool
+     */
+
+    public $incrementing = false;
+    /**
+     * The data type of the auto-incrementing ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+
+    /**
+     * Start the command
+     * @return CommandRun
+     */
+    public static function start(string $command): CommandRun {
+
+        $commandRun = CommandRun::create([
+            "command" => $command,
+            "status" => "started",
+            "started_at" => now(),
+        ]);
+        return $commandRun;
+    }
+
+    /**
+     * Get the ended_at date of the last command run
+     *
+     * @param  string  $command
+     * @return CommandRun
+     */
+
+    public static function lastEnded(string $command): CommandRun|null {
+        $lastCommandRun = CommandRun::where("command",
+            $command)->orderBy("ended_at",
+            "desc")->first();
+        return $lastCommandRun;
+    }
+
+    /**
+     * End the command
+     * @return CommandRun
+     */
+    public function end(): CommandRun {
+        $this->status = "ended";
+        $this->ended_at = now();
+        $this->save();
+        return $this;
+    }
+}

--- a/src/app/Models/CommandRun.php
+++ b/src/app/Models/CommandRun.php
@@ -60,7 +60,7 @@ class CommandRun extends Model
      */
 
     public static function lastEnded(string $command): CommandRun|null {
-        return CommandRun::whereCommand($command)->orderByDesc("ended_at")->first();
+        return CommandRun::whereCommand($command)->whereNotNull('ended_at')->orderByDesc("ended_at")->first();
     }
 
     /**

--- a/src/app/Models/Duplicate.php
+++ b/src/app/Models/Duplicate.php
@@ -160,6 +160,8 @@ class Duplicate extends Model
         $persons = $crew->persons;
         $similarities = [];
 
+
+        $last_comparison = CommandRun::lastEnded('duplicate:compute');
         // foreach persons
         foreach ($persons as $person) {
             //get the fields
@@ -170,7 +172,6 @@ class Duplicate extends Model
                 // do not compute a couple that has already been compared
 
                 // check if the persons have been edited since the last comparison
-                $last_comparison = CommandRun::lastEnded('duplicate:compute');
 
 
                 // compare the updated_at date of the persons with the last comparison date
@@ -182,6 +183,7 @@ class Duplicate extends Model
                 $notUpdatedSinceLastComparison = ($last_comparison == null || ($last_comparison->started_at < $person->updated_at || $last_comparison->started_at < $person2->updated_at));
                 $notResolved = !self::isResolved($person,
                     $person2);
+
                 if ($notSamePerson && $notAlreadyCompared && $notUpdatedSinceLastComparison && $notResolved) {
                     $person2_fields = $person2->fields;
                     $similarity = 0;

--- a/src/app/Models/Duplicate.php
+++ b/src/app/Models/Duplicate.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\Uuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -9,7 +10,31 @@ use Illuminate\Support\Facades\DB;
 
 class Duplicate extends Model
 {
-    use HasFactory, SoftDeletes;
+    use HasFactory, SoftDeletes, Uuids;
+
+    /**
+     * Indicates if the model's ID is auto-incrementing.
+     *
+     * @var bool
+     */
+
+    public $incrementing = false;
+
+    /**
+     * The data type of the auto-incrementing ID.
+     *
+     * @var string
+     */
+
+    protected $keyType = 'string';
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+
+    protected $guarded = [];
 
     /**
      * Returns duplicated values in array : Array ( [ABC-000004] => Array ( [0] => 5decaba8-f82f-4b61-858f-bfbf133f0c4f [1] => 95904830-52a5-4fad-982e-b0eed3a5f73b ) )
@@ -17,41 +42,49 @@ class Duplicate extends Model
      * @return array
      *
      */
-    public static function getDuplicates()
-    {
+    public static function getDuplicates() {
 
         $duplicate_ids = DB::table("refugees")->select("unique_id")->whereNull("deleted_at")->groupBy("unique_id")->havingRaw('count(*) > 1')->pluck("unique_id");
 
         if (empty($duplicate_ids)) {
-            return array();
+            return [];
         }
-        return Refugee::whereIn("unique_id", $duplicate_ids)->orderBy("date", "desc")->get()->groupBy('unique_id');
+        return Refugee::whereIn("unique_id",
+            $duplicate_ids)->orderBy("date",
+            "desc")->get()->groupBy('unique_id');
     }
 
-    public static function nextID($currentID)
-    {
-        $tricode = explode("-", $currentID)[0];
-        $last_unique_id_used = Refugee::where("unique_id", 'like', $tricode . "-" . "%")->orderBy("unique_id", "desc")->first()->unique_id;
-        $last_id = explode("-", $last_unique_id_used)[1];
-        return $tricode . "-" . str_pad((intval($last_id) + 1), 6, "0", STR_PAD_LEFT);
+    public static function nextID($currentID) {
+        $tricode = explode("-",
+            $currentID)[0];
+        $last_unique_id_used = Refugee::where("unique_id",
+            'like',
+            $tricode."-"."%")->orderBy("unique_id",
+            "desc")->first()->unique_id;
+        $last_id = explode("-",
+            $last_unique_id_used)[1];
+        return $tricode."-".str_pad((intval($last_id) + 1),
+                6, "0",
+                STR_PAD_LEFT);
     }
 
 
-    public static function getSimilarity($duplication_users)
-    {
+    public static function getSimilarity($duplication_users) {
         //die(var_dump($collection_to_parse));
-        $similarities = array();
-        $itemSimilarity = array();
+        $similarities = [];
+        $itemSimilarity = [];
         // [0] => { [elem0] => value00, [elem1] => value01, [elem2] => value02} , [1] => { [elem0] => value10, [elem1] => value11, [elem2] => value12} …
         foreach ($duplication_users as $userKey => $user) {
             //[elem0] => value00, [elem1] => value01, [elem2] => value02
             foreach ($user as $userItemKey => $userItemValue) {
 
-                if ($userItemKey != "id" && $userItemKey != "uninque_id" && $userItemKey != "created_at" && $userItemKey != "updated_at" && $userItemKey != "deleted" && $userItemKey != "api_log" && $userItemKey != "application_id") {
+                if ($userItemKey != "id" && $userItemKey != "unique_id" && $userItemKey != "created_at" && $userItemKey != "updated_at" && $userItemKey != "deleted" && $userItemKey != "api_log" && $userItemKey != "application_id") {
                     foreach ($duplication_users as $user2Key => $user2) {
                         //  print("Comparing {$item["full_name"]} with {$Parseitem["full_name"]} on $itemKey <br>");
                         if (isset($user2[$userItemKey]) && !empty($user2[$userItemKey])) {
-                            similar_text($userItemValue, $user2[$userItemKey], $perc);
+                            similar_text($userItemValue,
+                                $user2[$userItemKey],
+                                $perc);
                             $itemSimilarity[$userKey][$user2Key][$userItemKey] = $perc / 100;
                         }
 
@@ -72,36 +105,42 @@ class Duplicate extends Model
 
     /**
      * @param $value
-     * @param integer|float $min
-     * @param integer|float $max
+     * @param  integer|float  $min
+     * @param  integer|float  $max
      * @return string
      */
-    public static function make_color($value, $min = 0, $max = 1)
-    {
+    public static function make_color($value,
+        $min = 0, $max = 1) {
         $ratio = 1 - $value;
         if ($min > 0 || $max < 1) {
             if ($value < $min) {
                 $ratio = 1;
-            } else if ($value > $max) {
-                $ratio = 0;
             } else {
-                $range = $min - $max;
-                $ratio = ($value - $max) / $range;
+                if ($value > $max) {
+                    $ratio = 0;
+                } else {
+                    $range = $min - $max;
+                    $ratio = ($value - $max) / $range;
+                }
             }
         }
 
         $hue = ($ratio * 1.2) / 3.60;
-        $rgb = self::hsl_to_rgb($hue, 1, .5);
+        $rgb = self::hsl_to_rgb($hue,
+            1, .5);
 
-        $r = round($rgb['r'], 0);
-        $g = round($rgb['g'], 0);
-        $b = round($rgb['b'], 0);
+        $r = round($rgb['r'],
+            0);
+        $g = round($rgb['g'],
+            0);
+        $b = round($rgb['b'],
+            0);
 
         return "rgb($r,$g,$b)";
     }
 
-    protected static function hsl_to_rgb($h, $s, $l)
-    {
+    protected static function hsl_to_rgb($h,
+        $s, $l) {
 
         $r = $l;
         $g = $l;
@@ -150,6 +189,141 @@ class Duplicate extends Model
                     break;
             }
         }
-        return array('r' => $r * 255.0, 'g' => $g * 255.0, 'b' => $b * 255.0);
+        return [
+            'r' => $r * 255.0,
+            'g' => $g * 255.0,
+            'b' => $b * 255.0,
+        ];
+    }
+
+
+    /**
+     * This function is used to get similar persons. It compares the similarity of the persons based on the fields that are completed.
+     * It computes the similarity of each field and then averages the similarity of each field to get the similarity of the persons for a given team.
+     * @param  Crew  $crew
+     */
+    public static function getSimilarRefugees(Crew $crew) {
+        $persons = $crew->persons;
+        $similarities = [];
+        $nb_op = 0;
+        foreach ($persons as $person) {
+            //get the fields
+            $person_fields = $person->fields;
+            //compare similarity of each field with the other persons
+            foreach ($persons as $person2) {
+                if ($person->id != $person2->id) {
+                    $person2_fields = $person2->fields;
+                    $similarity = 0;
+                    $count = 0;
+                    foreach ($person_fields as $person_field) {
+                        foreach ($person2_fields as $person2_field) {
+                            $nb_op++;
+                            if ($person_field->id == $person2_field->id) {
+
+                                $perc = 0;
+                                similar_text($person_field->pivot->value,
+                                    $person2_field->pivot->value,
+                                    $perc);
+                                $similarity += $perc;
+                                $count++;
+                            }
+                        }
+                    }
+                    $similarity = $similarity / $count;
+                    $similarities[$person->best_descriptive_value][$person2->best_descriptive_value] = $similarity;
+                } else {
+                    $nb_op++;
+                }
+            }
+        }
+        dd($nb_op);
+        return $similarities;
+    }
+
+    /**
+     * This function is used to get similar persons. It compares the similarity of the persons based on the fields that are completed.
+     * It computes the similarity of each field and then averages the similarity of each field to get the similarity of the persons for a given team.
+     * It must not compute the similarity of a person with itself.
+     * It must not compute the similarity of a person with a person that has already been compared. (eg A -> B is the same as B -> A)
+     * It must not compute the similarity of a couple that has already been compared and not edited since.
+     * It must not compute the similarity of a couple marked as "not similar" (ie resolve) by the user.
+     *
+     * @param  Crew  $crew
+     */
+
+    public static function compute(Crew $crew) {
+        $persons = $crew->persons;
+        $similarities = [];
+
+        // foreach persons
+        foreach ($persons as $person) {
+            //get the fields
+            $person_fields = $person->fields;
+            //get all other persons
+            foreach ($persons as $person2) {
+                // do not compute the similarity of a person with itself
+                // do not compute a couple that has already been compared
+
+                // check if the persons have been edited since the last comparison
+                $last_comparison = CommandRun::lastEnded('duplicate:compute');
+
+
+                // compare the updated_at date of the persons with the last comparison date
+                // if the persons have been edited since the last comparison, then compute the similarity
+                // else, do not compute the similarity
+
+                $notSamePerson = $person->id != $person2->id;
+                $notAlreadyCompared = !isset($similarities[$person2->id][$person->id]);
+                $notUpdatedSinceLastComparison = ($last_comparison == null || ($last_comparison->ended_at < $person->updated_at || $last_comparison->ended_at < $person2->updated_at));
+                $notResolved = !self::isResolved($person,
+                    $person2);
+                if ($notSamePerson && $notAlreadyCompared && $notUpdatedSinceLastComparison && $notResolved) {
+                    $person2_fields = $person2->fields;
+                    $similarity = 0;
+                    $count = 0;
+                    foreach ($person_fields as $person_field) {
+                        foreach ($person2_fields as $person2_field) {
+                            if ($person_field->id == $person2_field->id) {
+                                $perc = 0;
+                                similar_text($person_field->pivot->value,
+                                    $person2_field->pivot->value,
+                                    $perc);
+                                $similarity += $perc;
+                                $count++;
+                            }
+                        }
+                    }
+                    $similarity = $similarity / $count;
+                    $similarities[$person->id][$person2->id] = $similarity;
+                }
+            }
+        }
+        return $similarities;
+    }
+
+    /**
+     * This function is used to check if a couple of persons has been marked as "not similar" (ie resolve) by the user.
+     * @param  Refugee  $person
+     * @param  Refugee  $person2
+     * @return boolean
+     */
+
+    public static function isResolved(Refugee $person,
+        Refugee $person2) {
+        $resolve = Duplicate::select(['resolved'])->where('person1_id',
+            $person->id)->where('person2_id',
+            $person2->id)->first();
+
+        if ($resolve != null && $resolve->resolved == 1) {
+            return true;
+        }
+        $resolve = Duplicate::select(['resolved'])->where('person1_id',
+            $person2->id)->where('person2_id',
+            $person->id)->first();
+
+        if ($resolve != null && $resolve->resolved == 1) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/app/Notifications/InviteUserNotification.php
+++ b/src/app/Notifications/InviteUserNotification.php
@@ -19,57 +19,46 @@ class InviteUserNotification extends Notification
      *
      * @return void
      */
-    public function __construct(User $inviter)
-    {
+    public function __construct(User $inviter) {
         $this->inviter = $inviter;
     }
 
     /**
      * Get the notification's delivery channels.
      *
-     * @param mixed $notifiable
+     * @param  mixed  $notifiable
      * @return array
      */
-    public function via($notifiable)
-    {
+    public function via($notifiable) {
         return ['mail'];
     }
 
     /**
      * Get the mail representation of the notification.
      *
-     * @param mixed $notifiable
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @param  mixed  $notifiable
+     * @return MailMessage
      */
-    public function toMail($notifiable)
-    {
+    public function toMail($notifiable) {
 
 
         $token = Password::broker('invites')->createToken($notifiable);
 
 
-        return (new MailMessage)
-            ->subject('Invitation to join ' . config('app.name'))
-            ->from(env('MAIL_FROM_EMAIL'), $this->inviter->name)
-            ->greeting('Hello ' . $notifiable->name . '!')
-            ->line($this->inviter->name . ' invited you to SCAN. In order to accept the invitation, please click the button below.')
-            ->line('You will be asked to set a password.')
-            ->action('Finalize my account creation !', url('/reset-password/' . $token . '?email=' . $notifiable->email))
-            ->line('You can find a complete documentation of the application here: ' . url('https://user-doc.netw4ppl.tech'))
-            ->line('Thank you for using our application!');
+        return (new MailMessage)->subject('Invitation to join '.config('app.name'))->from(env('MAIL_FROM_ADDRESS'),
+                $this->inviter->name)->greeting('Hello '.$notifiable->name.'!')->line($this->inviter->name.' invited you to SCAN. In order to accept the invitation, please click the button below.')->line('You will be asked to set a password.')->action('Finalize my account creation !',
+                url('/reset-password/'.$token.'?email='.$notifiable->email))->line('You can find a complete documentation of the application here: '.url('https://user-doc.netw4ppl.tech'))->line('Thank you for using our application!');
 
     }
 
     /**
      * Get the array representation of the notification.
      *
-     * @param mixed $notifiable
+     * @param  mixed  $notifiable
      * @return array
      */
-    public function toArray($notifiable)
-    {
-        return [
-            //
+    public function toArray($notifiable) {
+        return [//
         ];
     }
 }

--- a/src/app/Policies/DuplicatePolicy.php
+++ b/src/app/Policies/DuplicatePolicy.php
@@ -2,7 +2,9 @@
 
 namespace App\Policies;
 
+use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\Response;
 
 class DuplicatePolicy extends GlobalPolicy
 {
@@ -11,5 +13,32 @@ class DuplicatePolicy extends GlobalPolicy
     public function __construct($route_name = "duplicate")
     {
         parent::__construct($route_name);
+    }
+
+    /**
+     * Determine whether the user can force the duplicate compute command.
+     *
+     * @param  User  $user
+     * @return mixed
+     */
+
+    public function compute(User $user)
+    {
+        return $this->hasPermission($user, __FUNCTION__)
+            ? Response::allow()
+            : Response::deny('You do not have the right to do this.');
+    }
+    /**
+     * Determine whether the user can mark a duplicate as resolved.
+     *
+     * @param  User  $user
+     * @return mixed
+     */
+
+    public function resolve(User $user)
+    {
+        return $this->hasPermission($user, __FUNCTION__)
+            ? Response::allow()
+            : Response::deny('You do not have the right to do this.');
     }
 }

--- a/src/database/factories/CommandRunFactory.php
+++ b/src/database/factories/CommandRunFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CommandRun;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CommandRun>
+ */
+class CommandRunFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition() {
+        return [//
+        ];
+    }
+}

--- a/src/database/migrations/2022_11_15_135936_create_command_runs_table.php
+++ b/src/database/migrations/2022_11_15_135936_create_command_runs_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        Schema::create('command_runs',
+            function (Blueprint $table) {
+                $table->uuid("id")->primary();
+                $table->timestamps();
+                $table->softDeletes();
+                $table->timestamp("started_at")->nullable()->default(null);
+                $table->timestamp("ended_at")->nullable()->default(null);
+                $table->string("command");
+                $table->string("status");
+
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {
+        Schema::dropIfExists('command_runs');
+    }
+};

--- a/src/database/migrations/2022_11_15_143153_duplicates.php
+++ b/src/database/migrations/2022_11_15_143153_duplicates.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up() {
+        Schema::create('duplicates',
+            function (Blueprint $table) {
+                $table->uuid("id")->primary();
+                $table->timestamps();
+                $table->softDeletes();
+                $table->foreignUuid("person1_id");
+                $table->foreignUuid("person2_id");
+                $table->foreignUuid("command_run_id")->nullable();
+                $table->double("similarity")->nullable();
+                $table->boolean("resolved")->default(false);
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {
+        Schema::dropIfExists('duplicates');
+    }
+};

--- a/src/database/migrations/2022_11_15_143153_duplicates.php
+++ b/src/database/migrations/2022_11_15_143153_duplicates.php
@@ -18,6 +18,7 @@ return new class extends Migration {
                 $table->softDeletes();
                 $table->foreignUuid("person1_id");
                 $table->foreignUuid("person2_id");
+                $table->foreignUuid("crew_id");
                 $table->foreignUuid("command_run_id")->nullable();
                 $table->double("similarity")->nullable();
                 $table->boolean("resolved")->default(false);

--- a/src/database/seeders/LinkSeeder.php
+++ b/src/database/seeders/LinkSeeder.php
@@ -2,8 +2,8 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
 use App\Models\Link;
+use Illuminate\Database\Seeder;
 
 class LinkSeeder extends Seeder
 {
@@ -12,10 +12,7 @@ class LinkSeeder extends Seeder
      *
      * @return void
      */
-    public function run()
-    {
-        Link::factory()
-            ->count(40)
-            ->create();
+    public function run() {
+        Link::factory()->count(10)->create();
     }
 }

--- a/src/database/seeders/RefugeeSeeder.php
+++ b/src/database/seeders/RefugeeSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\Field;
 use App\Models\FieldRefugee;
 use App\Models\Refugee;
 use Illuminate\Database\Seeder;
@@ -14,13 +13,10 @@ class RefugeeSeeder extends Seeder
      *
      * @return void
      */
-    public function run()
-    {
-        $refugees = Refugee::factory()
-            ->count(200)
-            ->create();
+    public function run() {
+        $refugees = Refugee::factory()->count(20)->create();
 
-        foreach($refugees as $refugee){
+        foreach ($refugees as $refugee) {
             $refugee->fields()->attach(FieldRefugee::random_fields());
         }
 

--- a/src/resources/views/duplicate/index.blade.php
+++ b/src/resources/views/duplicate/index.blade.php
@@ -3,7 +3,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Manage duplicates - disabled for now') }}
+            {{ __('Manage duplicates') }}
         </h2>
     </x-slot>
 
@@ -12,15 +12,18 @@
             <div class="flex flex-wrap items-center justify-between">
                 <div class="flex w-0 flex-1 items-center">
                     <p class="ml-3 truncate font-bold text-white" style="margin-bottom: 0px !important;">
-                        <span class="text-l">Last run : {{ $lastRun->diffForHumans() }}</span> <br>
+                        <span class="text-l">Last run : {{ $lastRun == null ? 'Never' : $lastRun->diffForHumans() }}</span>
+                        <br>
                         <span class="text-l">Next due in : {{ $nextDue->diffForHumans() }}</span>
                     </p>
                 </div>
-                <div class="order-3 mt-2 w-full flex-shrink-0 sm:order-2 sm:mt-0 sm:w-auto">
-                    <a href="{{ route('duplicate.compute') }}"
-                       class="flex items-center justify-center rounded-md border border-transparent bg-white px-4 py-2 text-sm font-bold text-indigo-600 shadow-sm hover:bg-indigo-100">Force
-                        run</a>
-                </div>
+                @can('compute', Duplicate::class)
+                    <div class="order-3 mt-2 w-full flex-shrink-0 sm:order-2 sm:mt-0 sm:w-auto">
+                        <a href="{{ route('duplicate.compute') }}"
+                           class="flex items-center justify-center rounded-md border border-transparent bg-white px-4 py-2 text-sm font-bold text-indigo-600 shadow-sm hover:bg-indigo-100">Force
+                            run</a>
+                    </div>
+                @endcan
             </div>
         </div>
     </div>
@@ -52,10 +55,17 @@
                                             uppercase tracking-wider">
                                         Similarity
                                     </th>
+                                    @can('resolve', Duplicate::class)
+                                        <th scope="col"
+                                            class="px-6 py-3 text-left text-xs font-medium text-gray-500
+                                            uppercase tracking-wider">
+                                            Actions
+                                        </th>
+                                    @endcan
                                     <th scope="col"
                                         class="px-6 py-3 text-left text-xs font-medium text-gray-500
                                             uppercase tracking-wider">
-                                        Actions
+
                                     </th>
                                 </tr>
                                 </thead>
@@ -77,15 +87,19 @@
                                         <td class="px-6 py-4 whitespace-nowrap">
                                             {{ round($duplicate->similarity,2) }}
                                         </td>
-
+                                        @can('resolve', $duplicate)
+                                            <td class="px-6 py-4 whitespace-nowrap">
+                                                <a href="{{ route("duplicate.resolve", $duplicate->id) }}"
+                                                   class="text-indigo-600 hover:text-blue-900">Mark as not
+                                                    duplicated</a>
+                                            </td>
+                                        @endcan
                                         <td class="px-6 py-4 whitespace-nowrap">
                                             @if($duplicate->person1->updated_at > $commandRun->started_at || $duplicate->person2->updated_at > $commandRun->started_at)
                                                 <button class="btn btn-outline-danger">Updated Since last run</button>
                                             @endif
                                         </td>
-
                                     </tr>
-
                                 @endforeach
                                 <!-- More items... -->
                                 </tbody>

--- a/src/resources/views/duplicate/index.blade.php
+++ b/src/resources/views/duplicate/index.blade.php
@@ -7,102 +7,91 @@
         </h2>
     </x-slot>
 
+    <div class="bg-indigo-500">
+        <div class="mx-auto max-w-7xl py-3 px-3 sm:px-6 lg:px-8">
+            <div class="flex flex-wrap items-center justify-between">
+                <div class="flex w-0 flex-1 items-center">
+                    <p class="ml-3 truncate font-bold text-white" style="margin-bottom: 0px !important;">
+                        <span class="text-l">Last run : {{ $lastRun->diffForHumans() }}</span> <br>
+                        <span class="text-l">Next due in : {{ $nextDue->diffForHumans() }}</span>
+                    </p>
+                </div>
+                <div class="order-3 mt-2 w-full flex-shrink-0 sm:order-2 sm:mt-0 sm:w-auto">
+                    <a href="{{ route('duplicate.compute') }}"
+                       class="flex items-center justify-center rounded-md border border-transparent bg-white px-4 py-2 text-sm font-bold text-indigo-600 shadow-sm hover:bg-indigo-100">Force
+                        run</a>
+                </div>
+            </div>
+        </div>
+    </div>
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="flex flex-col">
                 <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
                     <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+
+
                         <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
-                            @foreach($duplicates as $reference => $duplicate)
-                                <h3 class="font-semibold text-l text-gray-800 leading-tight m-3">Duplication
-                                    on {{$reference}} </h3>
-                                <table class="min-w-full divide-y divide-gray-200">
-                                    <caption class="sr-only">Duplicated ids</caption>
-                                    <thead class="bg-gray-50">
+                            <h3 class="text-l text-gray-800 leading-tight m-3">Duplicate </h3>
+                            <table class="min-w-full divide-y divide-gray-200">
+                                <caption class="sr-only">Possible duplicate</caption>
+                                <thead class="bg-gray-50">
+                                <tr>
+                                    <th scope="col"
+                                        class="px-6 py-3 text-left text-xs font-medium text-gray-500
+                                            uppercase tracking-wider">
+                                        Person 1
+                                    </th>
+                                    <th scope="col"
+                                        class="px-6 py-3 text-left text-xs font-medium text-gray-500
+                                            uppercase tracking-wider">
+                                        Person 2
+                                    </th>
+                                    <th scope="col"
+                                        class="px-6 py-3 text-left text-xs font-medium text-gray-500
+                                            uppercase tracking-wider">
+                                        Similarity
+                                    </th>
+                                    <th scope="col"
+                                        class="px-6 py-3 text-left text-xs font-medium text-gray-500
+                                            uppercase tracking-wider">
+                                        Actions
+                                    </th>
+                                </tr>
+                                </thead>
+                                <tbody class="bg-white divide-y divide-gray-200">
+                                @foreach($duplicates as $duplicate)
                                     <tr>
-                                        <th scope="col"
-                                            class="px-6 py-3 text-left text-xs font-medium text-gray-500
-                                            uppercase tracking-wider">
-                                            Full Name
-                                        </th>
-                                        <th scope="col"
-                                            class="px-6 py-3 text-left text-xs font-medium text-gray-500
-                                            uppercase tracking-wider">
-                                            Date
-                                        </th>
-                                        <th scope="col"
-                                            class="px-6 py-3 text-left text-xs font-medium text-gray-500
-                                            uppercase tracking-wider">
-                                            Push informations
-                                        </th>
-                                        <th scope="col"
-                                            class="px-6 py-3 text-left text-xs font-medium text-gray-500
-                                            uppercase tracking-wider">
-                                            Actions
-                                        </th>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            <a href="{{route("person.show", $duplicate->person1->id)}}"
+                                               class="text-indigo-600 hover:text-blue-900">
+                                                {{$duplicate->person1->best_descriptive_value}}
+                                            </a>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            <a href="{{route("person.show", $duplicate->person2->id)}}"
+                                               class="text-indigo-600 hover:text-blue-900">
+                                                {{$duplicate->person2->best_descriptive_value}}
+                                            </a>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            {{ round($duplicate->similarity,2) }}
+                                        </td>
+
+                                        <td class="px-6 py-4 whitespace-nowrap">
+                                            @if($duplicate->person1->updated_at > $commandRun->started_at || $duplicate->person2->updated_at > $commandRun->started_at)
+                                                <button class="btn btn-outline-danger">Updated Since last run</button>
+                                            @endif
+                                        </td>
+
                                     </tr>
-                                    </thead>
-                                    <tbody class="bg-white divide-y divide-gray-200">
-                                    @foreach($duplicate as $user_information)
-                                        @php($next_reference = Duplicate::nextID($user_information->unique_id))
-                                        <tr>
-                                            <td class="px-6 py-4 whitespace-nowrap">
-                                                <a href="{{route("person.show", $user_information->id)}}"
-                                                   class="text-indigo-600 hover:text-blue-900">
-                                                    {{$user_information->full_name}}
-                                                    <small>({{$user_information->unique_id}})</small>
-                                                </a>
-                                            </td>
-                                            <td class="px-6 py-4 whitespace-nowrap">
-                                                {{$user_information->date}}
-                                            </td>
-                                            <td class="px-6 py-4 whitespace-nowrap">
-                                                <a href="{{route("api_logs.show", $user_information->api_log)}}"
-                                                   class="text-indigo-600 hover:text-blue-900">See push context</a>
-                                            </td>
-                                            <td class="px-6 py-4 whitespace-nowrap">
 
-                                                <form method="post"
-                                                      action="{{ route('person.fix_duplicated_reference', $user_information->id) }}">
-                                                    @csrf
-                                                    @method('PUT')
-                                                    <input type="hidden" name="unique_id" id="unique_id"
-                                                           value="{{$next_reference}}">
-                                                    <button type="submit"
-                                                            class="flex-shrink-0 bg-gray-200 hover:bg-gray-300
-                                                            text-black font-bold py-2 px-4 rounded"
-                                                            title="Auto change the ID!">Assign new ref :
-                                                        {{$next_reference}}</button>
-                                                </form>
-                                                <div class="block mb-2 mt-1">
-
-                                                    <form
-                                                        action="{{route('person.destroy', $user_information->id)}}"
-                                                        method="POST">
-                                                        <a href="{{route("person.edit", $user_information->id)}}"
-                                                           class="flex-shrink-0 bg-blue-200 hover:bg-blue-300
-                                                           text-black font-bold py-2 px-4 rounded mr-2">
-                                                            <em class="fas fa-edit text-blue-600 hover:text-blue-900"
-                                                                title="Edit this refugee!"></em>
-                                                        </a>
-                                                        @method('DELETE')
-                                                        @csrf
-                                                        <button type="submit"
-                                                                class="flex-shrink-0 bg-red-200 hover:bg-red-300
-                                                                text-black font-bold py-2 px-4 rounded">
-                                                            <em class="fas fa-trash text-red-600 hover:text-red-900 "
-                                                                title="Delete !"></em></button>
-                                                    </form>
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    @endforeach
-                                    <!-- More items... -->
-                                    </tbody>
-                                </table>
+                                @endforeach
+                                <!-- More items... -->
+                                </tbody>
+                            </table>
 
                         </div>
-                        @endforeach
                     </div>
                 </div>
             </div>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -179,6 +179,14 @@ Route::get('duplicate/compute',
         "as" => 'duplicate.compute',
         "uses" => "\App\Http\Controllers\DuplicateController@compute",
     ])->middleware('auth');
+
+Route::get('duplicate/resolve/{duplicate}',
+    [
+        "as" => 'duplicate.resolve',
+        "uses" => "\App\Http\Controllers\DuplicateController@resolve",
+    ])->middleware('auth');
+
+
 Route::resource("duplicate",
     DuplicateController::class)->middleware('auth');
 

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -30,123 +30,167 @@ Route::get('/', function () {
     return view('dashboard');
 })->name("/")->middleware('auth');
 
-Route::get('/content.json', function () {
-    return Storage::disk('public')->get('content.json');
-})->middleware('auth');
+Route::get('/content.json',
+    function () {
+        return Storage::disk('public')->get('content.json');
+    })->middleware('auth');
 
-Route::middleware(['auth:sanctum', 'verified'])->get('/dashboard', function () {
-    return view('dashboard');
-})->name('dashboard');
+Route::middleware([
+    'auth:sanctum',
+    'verified',
+])->get('/dashboard',
+    function () {
+        return view('dashboard');
+    })->name('dashboard');
 
 Route::get('cytoscape', [
     'as' => 'cytoscape.index',
-    'uses' => '\App\Http\Controllers\CytoscapeController@index'
+    'uses' => '\App\Http\Controllers\CytoscapeController@index',
 ])->middleware('auth');
 
-Route::get('person/json/create', [
-    'as' => 'person.create_from_json',
-    'uses' => '\App\Http\Controllers\RefugeeController@createFromJson'
-])->middleware('auth');
-Route::get('links/json/create', [
-    'as' => 'links.create_from_json',
-    'uses' => '\App\Http\Controllers\LinkController@createFromJson'
-])->middleware('auth');
-Route::post('person/json/store', [
-    'as' => 'person.store_from_json',
-    'uses' => '\App\Http\Controllers\RefugeeController@storeFromJson'
-])->middleware('auth');
-Route::post('links/json/store', [
-    'as' => 'links.store_from_json',
-    'uses' => '\App\Http\Controllers\LinkController@storeFromJson'
-])->middleware('auth');
-Route::post('user/request_role/{id}', [
-    'as' => 'user.request_role',
-    'uses' => '\App\Http\Controllers\ManageUsersController@RequestRole'
-])->middleware('auth');
-Route::post('user/change_team/{id}', [
-    'as' => 'user.change_team',
-    'uses' => '\App\Http\Controllers\ManageUsersController@ChangeTeam'
-])->middleware('auth');
-Route::get('user/grant_role/{id}', [
-    'as' => 'user.grant_role',
-    'uses' => '\App\Http\Controllers\ManageUsersController@GrantRole'
-])->middleware('auth');
-Route::get('user/reject_role/{id}', [
-    'as' => 'user.reject_role',
-    'uses' => '\App\Http\Controllers\ManageUsersController@RejectRole'
-])->middleware('auth');
+Route::get('person/json/create',
+    [
+        'as' => 'person.create_from_json',
+        'uses' => '\App\Http\Controllers\RefugeeController@createFromJson',
+    ])->middleware('auth');
+Route::get('links/json/create',
+    [
+        'as' => 'links.create_from_json',
+        'uses' => '\App\Http\Controllers\LinkController@createFromJson',
+    ])->middleware('auth');
+Route::post('person/json/store',
+    [
+        'as' => 'person.store_from_json',
+        'uses' => '\App\Http\Controllers\RefugeeController@storeFromJson',
+    ])->middleware('auth');
+Route::post('links/json/store',
+    [
+        'as' => 'links.store_from_json',
+        'uses' => '\App\Http\Controllers\LinkController@storeFromJson',
+    ])->middleware('auth');
+Route::post('user/request_role/{id}',
+    [
+        'as' => 'user.request_role',
+        'uses' => '\App\Http\Controllers\ManageUsersController@RequestRole',
+    ])->middleware('auth');
+Route::post('user/change_team/{id}',
+    [
+        'as' => 'user.change_team',
+        'uses' => '\App\Http\Controllers\ManageUsersController@ChangeTeam',
+    ])->middleware('auth');
+Route::get('user/grant_role/{id}',
+    [
+        'as' => 'user.grant_role',
+        'uses' => '\App\Http\Controllers\ManageUsersController@GrantRole',
+    ])->middleware('auth');
+Route::get('user/reject_role/{id}',
+    [
+        'as' => 'user.reject_role',
+        'uses' => '\App\Http\Controllers\ManageUsersController@RejectRole',
+    ])->middleware('auth');
 
-Route::get('lists_control/add_to_list/{list_control}', [
-    'as' => 'lists_control.add_to_list',
-    'uses' => '\App\Http\Controllers\ListControlController@AddToList'
-])->middleware('auth');
+Route::get('lists_control/add_to_list/{list_control}',
+    [
+        'as' => 'lists_control.add_to_list',
+        'uses' => '\App\Http\Controllers\ListControlController@AddToList',
+    ])->middleware('auth');
 
-Route::post('lists_control/update_list/{listControl}', [
-    'as' => 'lists_control.update_list',
-    'uses' => '\App\Http\Controllers\ListControlController@UpdateList'
-])->middleware('auth');
+Route::post('lists_control/update_list/{listControl}',
+    [
+        'as' => 'lists_control.update_list',
+        'uses' => '\App\Http\Controllers\ListControlController@UpdateList',
+    ])->middleware('auth');
 
-Route::put('person/fix_duplicated_reference/{id} ', [
-    'as' => 'person.fix_duplicated_reference',
-    'uses' => '\App\Http\Controllers\RefugeeController@fixDuplicatedReference'
-])->middleware('auth');
+Route::put('person/fix_duplicated_reference/{id} ',
+    [
+        'as' => 'person.fix_duplicated_reference',
+        'uses' => '\App\Http\Controllers\RefugeeController@fixDuplicatedReference',
+    ])->middleware('auth');
 
-Route::get('lists_control/create_fields/{listControl}', [
-    'as' => 'lists_control.create_fields',
-    'uses' => '\App\Http\Controllers\ListControlController@createFields'
-])->middleware('auth');
+Route::get('lists_control/create_fields/{listControl}',
+    [
+        'as' => 'lists_control.create_fields',
+        'uses' => '\App\Http\Controllers\ListControlController@createFields',
+    ])->middleware('auth');
 
-Route::post('lists_control/store_fields/{listControl}', [
-    'as' => 'lists_control.store_fields',
-    'uses' => '\App\Http\Controllers\ListControlController@storeFields'
-])->middleware('auth');
+Route::post('lists_control/store_fields/{listControl}',
+    [
+        'as' => 'lists_control.store_fields',
+        'uses' => '\App\Http\Controllers\ListControlController@storeFields',
+    ])->middleware('auth');
 
-Route::post('lists_control/store_displayed_value/{listControl}', [
-    'as' => 'lists_control.store_displayed_value',
-    'uses' => '\App\Http\Controllers\ListControlController@storeDisplayedValue'
-])->middleware('auth');
+Route::post('lists_control/store_displayed_value/{listControl}',
+    [
+        'as' => 'lists_control.store_displayed_value',
+        'uses' => '\App\Http\Controllers\ListControlController@storeDisplayedValue',
+    ])->middleware('auth');
 
-Route::delete('lists_control/{listControl}/delete_list_elem/{element}',[
-    'as' => 'lists_control.delete_list_elem',
-    'uses' => '\App\Http\Controllers\ListControlController@destroyListElem'
-])->middleware('auth');
+Route::delete('lists_control/{listControl}/delete_list_elem/{element}',
+    [
+        'as' => 'lists_control.delete_list_elem',
+        'uses' => '\App\Http\Controllers\ListControlController@destroyListElem',
+    ])->middleware('auth');
 
-Route::get('lists_control/{listControl}/edit/{element}', [
-    'as' => 'lists_control.edit_list_elem',
-    'uses' => '\App\Http\Controllers\ListControlController@editListElem'
-])->middleware('auth');
+Route::get('lists_control/{listControl}/edit/{element}',
+    [
+        'as' => 'lists_control.edit_list_elem',
+        'uses' => '\App\Http\Controllers\ListControlController@editListElem',
+    ])->middleware('auth');
 
-Route::post('lists_control/{listControl}/edit/{element}', [
-    'as' => 'lists_control.update_list_elem',
-    'uses' => '\App\Http\Controllers\ListControlController@updateListElem'
-])->middleware('auth');
+Route::post('lists_control/{listControl}/edit/{element}',
+    [
+        'as' => 'lists_control.update_list_elem',
+        'uses' => '\App\Http\Controllers\ListControlController@updateListElem',
+    ])->middleware('auth');
 
-Route::put('crew/{crew}/addUser', [
-    'as' => 'crew.addUser',
-    'uses' => '\App\Http\Controllers\CrewController@addUser'
-])->middleware('auth');
+Route::put('crew/{crew}/addUser',
+    [
+        'as' => 'crew.addUser',
+        'uses' => '\App\Http\Controllers\CrewController@addUser',
+    ])->middleware('auth');
 
-Route::resource("person", RefugeeController::class)->middleware('auth');
-Route::resource("fields", FieldsController::class)->middleware('auth');
-Route::resource("lists_control", ListControlController::class)->middleware('auth');
+Route::resource("person",
+    RefugeeController::class)->middleware('auth');
+Route::resource("fields",
+    FieldsController::class)->middleware('auth');
+Route::resource("lists_control",
+    ListControlController::class)->middleware('auth');
 
-Route::get("links/create/{origin?}/{refugee?}", [
-    "as" => 'links.create',
-    "uses" => '\App\Http\Controllers\LinkController@create'
-]);
-Route::resource("links", LinkController::class)->middleware('auth')->except(['create']);
+Route::get("links/create/{origin?}/{refugee?}",
+    [
+        "as" => 'links.create',
+        "uses" => '\App\Http\Controllers\LinkController@create',
+    ])->middleware('auth');
+Route::resource("links",
+    LinkController::class)->middleware('auth')->except(['create']);
 
 
-Route::resource("user", ManageUsersController::class)->middleware('auth');
-Route::post("user/invite/{user}", [
-    "as" => 'user.invite',
-    "uses" => '\App\Http\Controllers\ManageUsersController@invite'
-]);
+Route::resource("user",
+    ManageUsersController::class)->middleware('auth');
+Route::post("user/invite/{user}",
+    [
+        "as" => 'user.invite',
+        "uses" => '\App\Http\Controllers\ManageUsersController@invite',
+    ])->middleware('auth');
 
-Route::resource("duplicate", DuplicateController::class)->middleware('auth');
-Route::resource("api_logs", ApiLogController::class)->middleware('auth');
-Route::resource("crew", CrewController::class)->middleware('auth');
-Route::resource("roles", RoleController::class)->middleware('auth');
-Route::resource("permissions", PermissionController::class)->middleware('auth');
-Route::resource("event", EventController::class)->middleware('auth');
-Route::resource("source", SourceController::class)->middleware('auth');
+
+Route::get('duplicate/compute',
+    [
+        "as" => 'duplicate.compute',
+        "uses" => "\App\Http\Controllers\DuplicateController@compute",
+    ])->middleware('auth');
+Route::resource("duplicate",
+    DuplicateController::class)->middleware('auth');
+
+Route::resource("api_logs",
+    ApiLogController::class)->middleware('auth');
+Route::resource("crew",
+    CrewController::class)->middleware('auth');
+Route::resource("roles",
+    RoleController::class)->middleware('auth');
+Route::resource("permissions",
+    PermissionController::class)->middleware('auth');
+Route::resource("event",
+    EventController::class)->middleware('auth');
+Route::resource("source",
+    SourceController::class)->middleware('auth');

--- a/src/tests/Feature/DuplicateTest.php
+++ b/src/tests/Feature/DuplicateTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Models\Duplicate;
+use App\Models\FieldRefugee;
+use App\Models\Refugee;
 
 class DuplicateTest extends PermissionsTest
 {
@@ -21,5 +24,136 @@ class DuplicateTest extends PermissionsTest
             "destroy" => false,
         ];
     }
+
+    /**
+     * Test that a user can force duplicate compute command
+     */
+
+    public function test_user_with_permission_can_force_compute(){
+
+        $this->actingAs($this->admin)
+            ->get(route('duplicate.compute'))
+            ->assertStatus(302);
+    }
+    /**
+     * Test that a user without permission can't force duplicate compute command
+     */
+
+    public function test_user_without_permission_cant_force_compute(){
+
+        $this->actingAs($this->null)
+            ->get(route('duplicate.compute'))
+            ->assertStatus(403);
+    }
+
+    /**
+     * Test that the duplicate:compute artisan command is working when there were no updates in the database
+     */
+
+    public function test_duplicate_compute_command_no_update() {
+        $this->test_duplicate_compute_command();
+
+        // call the command again
+        $this->artisan('duplicate:compute')
+            ->assertExitCode(0)
+            ->expectsOutput('Computing duplicates for crew '.$this->admin->crew->name)
+            ->expectsOutputToContain('0'.' persons computed for crew '.$this->admin->crew->name);
+    }
+
+    /**
+     * Test that the duplicate:compute artisan command is working
+     */
+    public function test_duplicate_compute_command() {
+        //create some persons
+        $nbPersons = 5;
+        // add fields to these persons
+        foreach(Refugee::factory()->count($nbPersons)->create() as $person) {
+            $person->fields()->attach(FieldRefugee::random_fields());
+        }
+
+        // check that the persons are in the database
+        $this->assertCount($nbPersons, Refugee::all());
+        $this
+            ->artisan('duplicate:compute')
+            ->assertExitCode(0)
+            ->expectsOutput('Computing duplicates for crew '.$this->admin->crew->name)
+            ->expectsOutputToContain(($nbPersons -1).' persons computed for crew '.$this->admin->crew->name);
+
+    }
+
+    /**
+     * Test that a warning is displayed when a user had been edited since last run
+     */
+    public function test_edited_person_warning_is_displayed(){
+       // call the command to compute the duplicates
+        $this->test_duplicate_compute_command();
+
+        // check that the warning is not displayed
+        $this->actingAs($this->admin)
+            ->get(route('duplicate.index'))
+            ->assertDontSee('Updated Since last run');
+
+        // edit a person
+        $person = Refugee::first();
+
+        // mark the person as updated after the last run
+        $person->updated_at = now()->addDay();
+        $person->save();
+
+        // check that the warning is displayed
+        $this->actingAs($this->admin)
+            ->get(route('duplicate.index'))
+            ->assertSee('Updated Since last run');
+    }
+
+
+    /**
+     * Test that a duplicate can be marked as resolved
+     */
+
+    public function test_duplicate_can_be_marked_as_resolved() {
+        // call the command to compute the duplicates
+        $this->test_duplicate_compute_command();
+
+        // mark the first duplicate as resolved
+        $duplicate = Duplicate::where('resolved', false)->orderByDesc("similarity")->first();
+
+        // check that the duplicate is no more shown in the list
+        $this->actingAs($this->admin)
+            ->get(route('duplicate.index'))
+            ->assertSee($duplicate->id);
+
+        $this->actingAs($this->admin)
+            ->get(route('duplicate.resolve', $duplicate->id))
+            ->assertStatus(302);
+
+        //check that the duplicate as been marked as resolved in the database
+        $this->assertDatabaseHas('duplicates', [
+            'id' => $duplicate->id,
+            'resolved' => true
+        ]);
+
+        // check that the duplicate is no more shown in the list
+        $this->actingAs($this->admin)
+            ->get(route('duplicate.index'))
+            ->assertDontSee($duplicate->id);
+    }
+
+    // check that a user without permission can't mark a duplicate as resolved
+
+    public function test_user_without_permission_cant_mark_duplicate_as_resolved() {
+        // call the command to compute the duplicates
+        $this->test_duplicate_compute_command();
+
+        // mark the first duplicate as resolved
+        $duplicate = Duplicate::where('resolved', false)->orderByDesc("similarity")->first();
+
+        // check that the duplicate is no more shown in the list
+        $this->actingAs($this->null)
+            ->get(route('duplicate.resolve', $duplicate->id))
+            ->assertStatus(403);
+    }
+
+
 
 }

--- a/src/tests/Feature/UserTest.php
+++ b/src/tests/Feature/UserTest.php
@@ -41,7 +41,7 @@ class UserTest extends PermissionsTest
         $response = $this->delete($this->route.'/'.$this->resource->id);
 
         $response->assertStatus(302);
-        //check if the resource has been soft deleted
+        //check if the resource has been deleted
         $this->assertModelMissing($this->resource);
     }
 

--- a/src/tests/Feature/UserTest.php
+++ b/src/tests/Feature/UserTest.php
@@ -26,6 +26,25 @@ class UserTest extends PermissionsTest
     /* ---------------------------------------------------------- */
     /*----------------------------------------------------------- */
 
+    /**
+     * @brief An authenticated user, with '*.destroy' permission can delete a resource
+     */
+
+    public function test_authenticated_user_with_permission_can_delete_resource() {
+        if (!$this->run["destroy"]) {
+            return $this->markTestSkipped('This test is not relevant for the given route.');
+        }
+        if (get_called_class() == 'Tests\Feature\PermissionsTest') {
+            return $this->markTestSkipped('This is the parent class. It should not be tested.');
+        }
+        $this->actingAs($this->admin);
+        $response = $this->delete($this->route.'/'.$this->resource->id);
+
+        $response->assertStatus(302);
+        //check if the resource has been soft deleted
+        $this->assertModelMissing($this->resource);
+    }
+
     /* ------------------ changeTeam ------------------ */
 
     /**


### PR DESCRIPTION
### Description
Add a simple version of identity matching => a command can be run and scheduled to compute duplicate (based on distance)

Refactor duplicate page

Fix the #319 issue => no more returns useless data

Fix edit person bug (when editing someone, the newly edited value was detached)

Fix emails

## Issues fixed
List of related issues that are fixed by this PR :

Fix :
- #329
- #319 

## Commands to update

```
php artisan migrate
php artisan permissions:update
```

Please also add the following onto the cron table :
```
* * * * * cd /path-to-your-project && php artisan schedule:run >> /dev/null 2>&1
```

### Checklist
- [ ] Compiling
- [ ] Code factoring (comments, indent...)
- [ ] Documentation (net4p Doc, Readme...)

### Feature Checklist
- [ ] Cytoscape
- [ ] Person/Index
- [ ] Person/Filter
- [ ] Person/Create
- [ ] Person/Edit
- [ ] Person/Delete
- [ ] Relation/Index
- [ ] Relation/Filter
- [ ] Relation/Create
- [ ] Relation/Edit
- [ ] Relation/Delete
- [ ] Duplicates/Index
- [ ] Duplicates/Filter
- [ ] Duplicates/Create
- [ ] Duplicates/Edit
- [ ] ManageList/Delete
- [ ] ManageList/Create
- [ ] ManageList/Edit
- [ ] ManageField/Index
- [ ] ManageField/Create
- [ ] ManageField/Edit
- [ ] ManageField/Delete
- [ ] ApiList
- [ ] Crews
- [ ] Users
