### PR TITLE
[PR] hotfix(cytoscape): Cytoscape 500 errror

### DIFF
--- a/src/app/Http/Controllers/CytoscapeController.php
+++ b/src/app/Http/Controllers/CytoscapeController.php
@@ -3,6 +3,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Cytoscape;
 use App\Models\Field;
+use App\Models\Link;
 use App\Models\ListControl;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
@@ -21,13 +22,13 @@ class CytoscapeController extends Controller
 
     public function index()
     {
-        $relations = \App\Models\Link::whereRelation('RefugeeFrom.crew', 'crews.id', Auth::user()->crew->id)
+        $relations = Link::whereRelation('RefugeeFrom.crew', 'crews.id', Auth::user()->crew->id)
             ->whereRelation('RefugeeTo.crew', 'crews.id', Auth::user()->crew->id)
             ->get();
 
         //get the role field
         $role_list = ListControl::firstWhere('name', 'ListRole');
-        $role_field = Field::whereCrewId(Auth::user()->crew->id)->firstWhere('linked_list', $role_list->id);
+        $role_field = Field::whereCrewId(Auth::user()->crew->id)->where('linked_list', $role_list->id);
         /*
             $nodes = array();
             foreach ($refugees as $refugee){
@@ -45,7 +46,7 @@ class CytoscapeController extends Controller
             $node["data"] = array();
             $node["data"]["id"] = $relation->getFromId();
             $node["data"]["name"] = $relation->refugeeFrom->best_descriptive_value;
-            if ($role_field->exists()) {
+            if ($role_field->exists() && $relation->refugeeFrom->fields->where('id', $role_field->first()->id)->count() > 0) {
                 $model = "App\Models\\" . $role_list->name; // App\Models\ListRole
                 $value = $model::find($relation->refugeeFrom->fields->firstWhere('id', $role_field->id)->pivot->value)->{$role_list->displayed_value};
                 $node["data"]["role"] = $value;
@@ -55,7 +56,7 @@ class CytoscapeController extends Controller
             $node["data"] = array();
             $node["data"]["id"] = $relation->getToId();
             $node["data"]["name"] = $relation->refugeeTo->best_descriptive_value;
-            if ($role_field->exists()) {
+            if ($role_field->exists() && $relation->refugeeTo->fields->where('id', $role_field->first()->id)->count() > 0) {
                 $model = "App\Models\\" . $role_list->name; // App\Models\ListRole
                 $value = $model::find($relation->refugeeTo->fields->firstWhere('id', $role_field->id)->pivot->value)->{$role_list->displayed_value};
                 $node["data"]["role"] = $value;


### PR DESCRIPTION
Error while checking the exsitance of role in cytoscape controller

issue: #342
Signed-off-by: Lduf <lucas.dufour@insa-lyon.fr>

### Description
This bug had already been fixed in the dev branch.
The cause was the way we checked if the role field exists in the current crew.

## Issues fixed
List of related issues that are fixed by this PR :

Fix :
- #342 


### Checklist
- [ ] Compiling
- [ ] Code factoring (comments, indent...)
- [ ] Documentation (net4p Doc, Readme...)

### Feature Checklist
- [ ] Cytoscape
- [ ] Person/Index
- [ ] Person/Filter
- [ ] Person/Create
- [ ] Person/Edit
- [ ] Person/Delete
- [ ] Relation/Index
- [ ] Relation/Filter
- [ ] Relation/Create
- [ ] Relation/Edit
- [ ] Relation/Delete
- [ ] Duplicates/Index
- [ ] Duplicates/Filter
- [ ] Duplicates/Create
- [ ] Duplicates/Edit
- [ ] ManageList/Delete
- [ ] ManageList/Create
- [ ] ManageList/Edit
- [ ] ManageField/Index
- [ ] ManageField/Create
- [ ] ManageField/Edit
- [ ] ManageField/Delete
- [ ] ApiList
- [ ] Crews
- [ ] Users
